### PR TITLE
N-04: standard storage gap

### DIFF
--- a/src/RLUSDGuardian.sol
+++ b/src/RLUSDGuardian.sol
@@ -344,6 +344,6 @@ contract RLUSDGuardian is
     /* --------------------------------------------------------------------- */
     /*                       Storage gap for future upgrades                 */
     /* --------------------------------------------------------------------- */
-    /// @dev Storage gap for future upgrades. The supply-manager mapping consumes 1 slot from this gap.
-    uint256[49] private __gap; // supply-manager mapping consumes 1 slot from this gap
+    /// @dev Storage gap for future upgrades.
+    uint256[50] private __gap;
 }


### PR DESCRIPTION
Uses the OpenZeppelin-recommended 50-slot gap. Audit note N-04.